### PR TITLE
Enable manual trigger for Docker image CI workflow

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,19 @@
+name: Docker Image CI
+
+on:
+  workflow_dispatch:
+    inputs:
+      tagName:
+        description: 'Tag name'
+        required: true
+        default: 'latest'
+        type: string
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag blog-system-ai:$TAG_NAME
+      env:
+        TAG_NAME: ${{ inputs.tagName }}


### PR DESCRIPTION
Added workflow_dispatch event to allow manual triggering with a tag input.