### PR TITLE
Enhance code blocks with line numbers, scroll container, and improved UX

### DIFF
--- a/VERSION.md
+++ b/VERSION.md
@@ -456,3 +456,4 @@
 - Rozszerzono renderer artykułów o prawdziwie zagnieżdżone listy oparte na wcięciach oraz dopasowano style `ul/ol` na `blog_show`, aby dzieci list miały poprawne wcięcia i zróżnicowane markery.
 - Dodano offset przewijania dla nagłówków z kotwicami, tak aby wejście na adres z `#fragment` nie chowało nagłówka pod górnym menu.
 - Zmniejszono odstęp między panelem `Spisu treści` a pierwszym nagłówkiem treści artykułu, redukując dolny margines TOC i zerując górny margines pierwszego bloku nagłówkowego.
+- Rozbudowano bloki kodu na `blog_show` o numerację linii generowaną przez `ArticleMarkupRenderer`, własny wewnętrzny kontener przewijania poziomego z dopracowanym scrollbar'em oraz mocniejszy efekt hover, który podświetla numer linii po najechaniu na treść danego wiersza.

--- a/VERSION.md
+++ b/VERSION.md
@@ -456,4 +456,4 @@
 - Rozszerzono renderer artykułów o prawdziwie zagnieżdżone listy oparte na wcięciach oraz dopasowano style `ul/ol` na `blog_show`, aby dzieci list miały poprawne wcięcia i zróżnicowane markery.
 - Dodano offset przewijania dla nagłówków z kotwicami, tak aby wejście na adres z `#fragment` nie chowało nagłówka pod górnym menu.
 - Zmniejszono odstęp między panelem `Spisu treści` a pierwszym nagłówkiem treści artykułu, redukując dolny margines TOC i zerując górny margines pierwszego bloku nagłówkowego.
-- Rozbudowano bloki kodu na `blog_show` o numerację linii generowaną przez `ArticleMarkupRenderer`, własny wewnętrzny kontener przewijania poziomego z dopracowanym scrollbar'em oraz mocniejszy efekt hover, który podświetla numer linii po najechaniu na treść danego wiersza.
+- Rozbudowano bloki kodu na `blog_show` o numerację linii generowaną przez `ArticleMarkupRenderer`, własny wewnętrzny kontener przewijania poziomego z dopracowanym scrollbarem oraz mocniejszy efekt hover, który podświetla numer linii po najechaniu na treść danego wiersza.

--- a/public/assets/css/pages/blog.css
+++ b/public/assets/css/pages/blog.css
@@ -911,7 +911,8 @@
   margin-top:0;
 }
 
-.article-body pre{
+.article-body .article-preformatted,
+.article-body .article-code-block{
   margin:1.8rem 0;
   padding:1rem 1.1rem;
   overflow:hidden;
@@ -922,6 +923,15 @@
 
 .article-body .article-code-block{
   padding:.9rem 0 .2rem;
+}
+
+.article-body .article-code-block pre{
+  margin:0;
+  padding:0;
+  overflow:visible;
+  border:0;
+  border-radius:0;
+  background:transparent;
 }
 
 .article-body .article-code-scroll{
@@ -937,6 +947,7 @@
 .article-body .article-code-block code{
   display:block;
   min-width:max-content;
+  line-height:0;
 }
 
 .article-body .article-code-line{
@@ -947,6 +958,7 @@
   width:max-content;
   min-width:100%;
   padding:0 1.5rem 0 .1rem;
+  line-height:1.6;
 }
 
 .article-body .article-code-line-number{
@@ -997,11 +1009,11 @@
   background-clip:padding-box;
 }
 
-.article-body > :first-child:is(blockquote, pre){
+.article-body > :first-child:is(blockquote, pre, .article-code-block){
   margin-top:0;
 }
 
-.article-body > :last-child:is(blockquote, pre){
+.article-body > :last-child:is(blockquote, pre, .article-code-block){
   margin-bottom:0;
 }
 

--- a/public/assets/css/pages/blog.css
+++ b/public/assets/css/pages/blog.css
@@ -914,10 +914,87 @@
 .article-body pre{
   margin:1.8rem 0;
   padding:1rem 1.1rem;
-  overflow-x:auto;
+  overflow:hidden;
   border:1px solid color-mix(in oklab, var(--accent-2) 18%, var(--border));
   border-radius:16px;
   background: color-mix(in oklab, var(--panel-2) 96%, transparent);
+}
+
+.article-body .article-code-block{
+  padding:.9rem 0 .2rem;
+}
+
+.article-body .article-code-scroll{
+  width:calc(100% - .6rem);
+  margin:0 auto;
+  padding-bottom:.1rem;
+  overflow-x:auto;
+  scrollbar-gutter:stable;
+  scrollbar-width:thin;
+  scrollbar-color:color-mix(in oklab, var(--accent-2) 26%, var(--border)) transparent;
+}
+
+.article-body .article-code-block code{
+  display:block;
+  min-width:max-content;
+}
+
+.article-body .article-code-line{
+  display:grid;
+  grid-template-columns:3rem minmax(0, 1fr);
+  align-items:start;
+  gap:.95rem;
+  width:max-content;
+  min-width:100%;
+  padding:0 1.5rem 0 .1rem;
+}
+
+.article-body .article-code-line-number{
+  display:block;
+  user-select:none;
+  text-align:right;
+  color:color-mix(in oklab, var(--muted) 78%, var(--accent) 22%);
+  border-right:1px solid color-mix(in oklab, var(--accent-2) 14%, var(--border));
+  padding-right:.75rem;
+  border-radius:10px 0 0 10px;
+  transition:color .18s ease, border-color .18s ease, background-color .18s ease, box-shadow .18s ease;
+}
+
+.article-body .article-code-line-content{
+  display:block;
+  min-width:0;
+}
+
+.article-body .article-code-line:hover .article-code-line-number{
+  color:color-mix(in oklab, var(--accent) 88%, var(--text) 12%);
+  border-right-color:color-mix(in oklab, var(--accent) 58%, var(--border));
+  background:color-mix(in oklab, var(--accent) 14%, transparent);
+  box-shadow:inset -1px 0 0 color-mix(in oklab, var(--accent) 34%, transparent);
+}
+
+.article-body .article-code-line-content:empty::before{
+  content:" ";
+  white-space:pre;
+}
+
+.article-body .article-code-scroll::-webkit-scrollbar{
+  height:12px;
+}
+
+.article-body .article-code-scroll::-webkit-scrollbar-track{
+  background:transparent;
+}
+
+.article-body .article-code-scroll::-webkit-scrollbar-thumb{
+  border:3px solid transparent;
+  border-radius:999px;
+  background:color-mix(in oklab, var(--accent-2) 26%, var(--border));
+  background-clip:padding-box;
+}
+
+.article-body .article-code-scroll::-webkit-scrollbar-thumb:hover{
+  background:color-mix(in oklab, var(--accent) 32%, var(--border));
+  background-clip:padding-box;
 }
 
 .article-body > :first-child:is(blockquote, pre){

--- a/src/Service/ArticleMarkupRenderer.php
+++ b/src/Service/ArticleMarkupRenderer.php
@@ -407,9 +407,9 @@ final class ArticleMarkupRenderer
         }
 
         return sprintf(
-            '<pre class="article-code-block"><div class="article-code-scroll"><code%s>%s</code></div></pre>',
+            '<div class="article-code-block"><div class="article-code-scroll"><pre><code%s>%s</code></pre></div></div>',
             $languageClass,
-            implode('', $renderedLines),
+            implode("\n", $renderedLines),
         );
     }
 

--- a/src/Service/ArticleMarkupRenderer.php
+++ b/src/Service/ArticleMarkupRenderer.php
@@ -151,12 +151,7 @@ final class ArticleMarkupRenderer
                 return;
             }
 
-            $languageClass = '' !== $code ? ' class="language-'.htmlspecialchars($code, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8').'"' : '';
-            $blocks[] = sprintf(
-                '<pre><code%s>%s</code></pre>',
-                $languageClass,
-                htmlspecialchars(implode("\n", $codeLines), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'),
-            );
+            $blocks[] = self::renderCodeBlock($code, $codeLines);
 
             $code = null;
             $codeLines = [];
@@ -393,6 +388,29 @@ final class ArticleMarkupRenderer
         }
 
         return self::renderInline($result);
+    }
+
+    /**
+     * @param list<string> $lines
+     */
+    private static function renderCodeBlock(?string $language, array $lines): string
+    {
+        $languageClass = '' !== (string) $language ? ' class="language-'.htmlspecialchars((string) $language, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8').'"' : '';
+        $renderedLines = [];
+
+        foreach ($lines as $index => $line) {
+            $renderedLines[] = sprintf(
+                '<span class="article-code-line"><span class="article-code-line-number" aria-hidden="true">%d</span><span class="article-code-line-content">%s</span></span>',
+                $index + 1,
+                htmlspecialchars($line, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'),
+            );
+        }
+
+        return sprintf(
+            '<pre class="article-code-block"><div class="article-code-scroll"><code%s>%s</code></div></pre>',
+            $languageClass,
+            implode('', $renderedLines),
+        );
     }
 
     private static function normalizeHeadingTitleForTableOfContents(string $title): string

--- a/tests/Unit/Service/ArticleMarkupRendererTest.php
+++ b/tests/Unit/Service/ArticleMarkupRendererTest.php
@@ -50,7 +50,11 @@ TEXT);
         $this->assertStringContainsString('<blockquote><p>Cytat testowy</p></blockquote>', $html);
         $this->assertStringContainsString('<a href="https://openai.com" target="_blank" rel="noopener noreferrer">OpenAI</a>', $html);
         $this->assertStringContainsString('<img src="https://example.com/test.png" alt="Alt" loading="lazy">', $html);
-        $this->assertStringContainsString('<pre class="article-code-block"><div class="article-code-scroll"><code class="language-php"><span class="article-code-line"><span class="article-code-line-number" aria-hidden="true">1</span><span class="article-code-line-content">echo &#039;hi&#039;;</span></span></code></div></pre>', $html);
+        $this->assertStringContainsString('<div class="article-code-block">', $html);
+        $this->assertStringContainsString('<div class="article-code-scroll">', $html);
+        $this->assertStringContainsString('<code class="language-php">', $html);
+        $this->assertStringContainsString('<span class="article-code-line-number" aria-hidden="true">1</span>', $html);
+        $this->assertStringContainsString('<span class="article-code-line-content">echo &#039;hi&#039;;</span>', $html);
     }
 
     public function testRendersNestedListsWithChildren(): void
@@ -171,10 +175,16 @@ console.log(value);
 ```
 TEXT);
 
-        $this->assertStringContainsString('<pre class="article-code-block"><div class="article-code-scroll"><code class="language-js">', $html);
-        $this->assertStringContainsString('<span class="article-code-line"><span class="article-code-line-number" aria-hidden="true">1</span><span class="article-code-line-content">const value = 1;</span></span>', $html);
-        $this->assertStringContainsString('<span class="article-code-line"><span class="article-code-line-number" aria-hidden="true">2</span><span class="article-code-line-content"></span></span>', $html);
-        $this->assertStringContainsString('<span class="article-code-line"><span class="article-code-line-number" aria-hidden="true">3</span><span class="article-code-line-content">console.log(value);</span></span>', $html);
+        $this->assertStringContainsString('<div class="article-code-block">', $html);
+        $this->assertStringContainsString('<div class="article-code-scroll">', $html);
+        $this->assertStringContainsString('<code class="language-js">', $html);
+        $this->assertStringContainsString('<span class="article-code-line-number" aria-hidden="true">1</span>', $html);
+        $this->assertStringContainsString('<span class="article-code-line-content">const value = 1;</span>', $html);
+        $this->assertStringContainsString('<span class="article-code-line-number" aria-hidden="true">2</span>', $html);
+        $this->assertStringContainsString('<span class="article-code-line-content"></span>', $html);
+        $this->assertStringContainsString('<span class="article-code-line-number" aria-hidden="true">3</span>', $html);
+        $this->assertStringContainsString('<span class="article-code-line-content">console.log(value);</span>', $html);
+        $this->assertStringContainsString("</span>\n<span class=\"article-code-line\">", $html);
     }
 
     public function testRendersForcedLineBreakSeparatorAndTable(): void
@@ -342,7 +352,10 @@ TEXT;
         $html = $renderer->render($input);
         $toc = $renderer->extractTableOfContents($input);
 
-        $this->assertStringContainsString('<pre class="article-code-block"><div class="article-code-scroll"><code class="language-php"><span class="article-code-line"><span class="article-code-line-number" aria-hidden="true">1</span><span class="article-code-line-content">echo &#039;one&#039;;</span></span></code></div></pre>', $html);
+        $this->assertStringContainsString('<div class="article-code-block">', $html);
+        $this->assertStringContainsString('<div class="article-code-scroll">', $html);
+        $this->assertStringContainsString('<code class="language-php">', $html);
+        $this->assertStringContainsString('<span class="article-code-line-content">echo &#039;one&#039;;</span>', $html);
         $this->assertStringContainsString('<h2 id="dalej">Dalej</h2>', $html);
         $this->assertSame([
             ['id' => 'dalej', 'level' => 2, 'title' => 'Dalej'],

--- a/tests/Unit/Service/ArticleMarkupRendererTest.php
+++ b/tests/Unit/Service/ArticleMarkupRendererTest.php
@@ -50,7 +50,7 @@ TEXT);
         $this->assertStringContainsString('<blockquote><p>Cytat testowy</p></blockquote>', $html);
         $this->assertStringContainsString('<a href="https://openai.com" target="_blank" rel="noopener noreferrer">OpenAI</a>', $html);
         $this->assertStringContainsString('<img src="https://example.com/test.png" alt="Alt" loading="lazy">', $html);
-        $this->assertStringContainsString('<pre><code class="language-php">echo &#039;hi&#039;;</code></pre>', $html);
+        $this->assertStringContainsString('<pre class="article-code-block"><div class="article-code-scroll"><code class="language-php"><span class="article-code-line"><span class="article-code-line-number" aria-hidden="true">1</span><span class="article-code-line-content">echo &#039;hi&#039;;</span></span></code></div></pre>', $html);
     }
 
     public function testRendersNestedListsWithChildren(): void
@@ -157,6 +157,24 @@ linia 1
 TEXT);
 
         $this->assertStringContainsString("<pre class=\"article-preformatted\">linia 1\n  linia 2\n&lt;b&gt;bez html&lt;/b&gt;</pre>", $html);
+    }
+
+    public function testRendersCodeBlockWithLineNumbersForEachLine(): void
+    {
+        $renderer = new ArticleMarkupRenderer();
+
+        $html = $renderer->render(<<<'TEXT'
+```js
+const value = 1;
+
+console.log(value);
+```
+TEXT);
+
+        $this->assertStringContainsString('<pre class="article-code-block"><div class="article-code-scroll"><code class="language-js">', $html);
+        $this->assertStringContainsString('<span class="article-code-line"><span class="article-code-line-number" aria-hidden="true">1</span><span class="article-code-line-content">const value = 1;</span></span>', $html);
+        $this->assertStringContainsString('<span class="article-code-line"><span class="article-code-line-number" aria-hidden="true">2</span><span class="article-code-line-content"></span></span>', $html);
+        $this->assertStringContainsString('<span class="article-code-line"><span class="article-code-line-number" aria-hidden="true">3</span><span class="article-code-line-content">console.log(value);</span></span>', $html);
     }
 
     public function testRendersForcedLineBreakSeparatorAndTable(): void
@@ -324,7 +342,7 @@ TEXT;
         $html = $renderer->render($input);
         $toc = $renderer->extractTableOfContents($input);
 
-        $this->assertStringContainsString('<pre><code class="language-php">echo &#039;one&#039;;</code></pre>', $html);
+        $this->assertStringContainsString('<pre class="article-code-block"><div class="article-code-scroll"><code class="language-php"><span class="article-code-line"><span class="article-code-line-number" aria-hidden="true">1</span><span class="article-code-line-content">echo &#039;one&#039;;</span></span></code></div></pre>', $html);
         $this->assertStringContainsString('<h2 id="dalej">Dalej</h2>', $html);
         $this->assertSame([
             ['id' => 'dalej', 'level' => 2, 'title' => 'Dalej'],


### PR DESCRIPTION
- Rozbudowano bloki kodu na `blog_show` o numerację linii generowaną przez `ArticleMarkupRenderer`, własny wewnętrzny kontener przewijania poziomego z dopracowanym scrollbarem oraz mocniejszy efekt hover, który podświetla numer linii po najechaniu na treść danego wiersza.