### PR TITLE
Refine article rendering: paragraph-based lines, block handling, and styling adjustments

### DIFF
--- a/VERSION.md
+++ b/VERSION.md
@@ -495,3 +495,10 @@
 - Rozbudowano wstęp `README.md` o opis celu projektu, głównych możliwości aplikacji, technicznych fundamentów oraz informacji, że większość implementacji powstaje z pomocą AI i jest dalej utrzymywana w normalnym workflow inżynierskim.
 - Uporządkowano strukturę `README.md`, przenosząc najważniejsze sekcje startowe na górę dokumentu, rozdzielając treści dotyczące serwera developerskiego, assetów, crona oraz kolejek importu i eksportu, a także przenosząc `Next steps` na koniec pliku.
 - Dodano do `README.md` spis treści zgodny z aktualną hierarchią sekcji, wraz z ikonami dla głównych nagłówków `##` i odpowiadających im pozycji w spisie treści.
+
+## 2026-05-01
+
+- Zmieniono renderowanie zwykłej treści artykułu w `ArticleMarkupRenderer`, tak aby każda linia tekstu była osobnym tagiem `<p>`, a puste linie oraz linie z samym `\` były renderowane jako osobne `<br>` bez konieczności łączenia całej treści w jeden paragraf.
+- Uspójniono renderowanie bloków nietekstowych w treści artykułu: samodzielne obrazy Markdown są emitowane jako `<img>` poza paragrafem, a tabele pozostają osobnymi blokami HTML bez opakowania w `<p>`.
+- Dopasowano style publicznego widoku artykułu do nowej struktury treści, zdejmując dodatkowy odstęp między kolejnymi liniami `<p>` i pustymi liniami `<br>` oraz zmniejszając bazowy `line-height` treści.
+- Zaktualizowano podpowiedź formatowania w formularzu artykułu oraz rozszerzono testy jednostkowe renderera o zachowanie pustych linii, linii z `\`, samodzielnych obrazów i tekstowych linii renderowanych jako osobne paragrafy.

--- a/public/assets/css/pages/blog.css
+++ b/public/assets/css/pages/blog.css
@@ -779,7 +779,7 @@
 }
 
 .article-body {
-  line-height:1.75;
+  line-height:1.5;
   color:var(--text);
 }
 
@@ -832,6 +832,13 @@
 
 .article-body p{
   margin:0;
+}
+
+.article-body > p + p,
+.article-body > p + br,
+.article-body > br + p,
+.article-body > br + br{
+  margin-top:0;
 }
 
 .article-body ul,

--- a/src/Service/ArticleMarkupRenderer.php
+++ b/src/Service/ArticleMarkupRenderer.php
@@ -6,7 +6,6 @@ namespace App\Service;
 
 final class ArticleMarkupRenderer
 {
-    private const LINE_BREAK_TOKEN = '@@ARTICLE_LINE_BREAK@@';
     /**
      * Keep only the last parsed document to avoid unbounded growth on shared service instances.
      *
@@ -76,7 +75,7 @@ final class ArticleMarkupRenderer
                 return;
             }
 
-            $blocks[] = '<p>'.self::renderParagraphLines($paragraph).'</p>';
+            $blocks[] = self::renderParagraphLines($paragraph);
             $paragraph = [];
         };
 
@@ -266,6 +265,15 @@ final class ArticleMarkupRenderer
             }
 
             if ('' === trim($line)) {
+                if ([] !== $paragraph) {
+                    $nextContentIndex = self::findNextContentLineIndex($lines, $index + 1);
+                    if (null !== $nextContentIndex && !self::isBlockStart($lines, $nextContentIndex)) {
+                        $paragraph[] = '';
+
+                        continue;
+                    }
+                }
+
                 $flushParagraph();
                 $flushList();
                 $flushQuote();
@@ -373,23 +381,30 @@ final class ArticleMarkupRenderer
 
     private static function renderParagraphLines(array $lines): string
     {
-        $result = '';
-        $previousEndedWithBreak = false;
+        $blocks = [];
 
-        foreach ($lines as $index => $line) {
+        foreach ($lines as $line) {
             $trimmed = trim($line);
             $lineBreak = str_ends_with($trimmed, '\\');
             $content = $lineBreak ? rtrim(substr($trimmed, 0, -1)) : $trimmed;
 
-            if ($index > 0) {
-                $result .= $previousEndedWithBreak ? self::LINE_BREAK_TOKEN : ' ';
+            if ('' === $content) {
+                $blocks[] = '<br>';
+
+                continue;
             }
 
-            $result .= $content;
-            $previousEndedWithBreak = $lineBreak;
+            $standaloneImage = self::renderStandaloneImage($content);
+            if (null !== $standaloneImage) {
+                $blocks[] = $standaloneImage;
+
+                continue;
+            }
+
+            $blocks[] = '<p>'.self::renderInline($content).'</p>';
         }
 
-        return self::renderInline($result);
+        return implode("\n", $blocks);
     }
 
     private static function parseCodeFence(string $line): ?string
@@ -399,6 +414,40 @@ final class ArticleMarkupRenderer
         }
 
         return isset($matches[1]) ? strtolower($matches[1]) : '';
+    }
+
+    /**
+     * @param list<string> $lines
+     */
+    private static function findNextContentLineIndex(array $lines, int $startIndex): ?int
+    {
+        $lineCount = count($lines);
+
+        for ($index = $startIndex; $index < $lineCount; ++$index) {
+            if ('' !== trim($lines[$index])) {
+                return $index;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param list<string> $lines
+     */
+    private static function isBlockStart(array $lines, int $index): bool
+    {
+        $line = $lines[$index];
+        $trimmed = trim($line);
+
+        return null !== self::parseCodeFence($line)
+            || ':::pre' === strtolower($trimmed)
+            || preg_match('/^:::(left|center|right|justify)\s*$/i', $trimmed) === 1
+            || self::isTableStart($lines, $index)
+            || preg_match('/^\s*([-*_])(?:\s*\1){2,}\s*$/', $line) === 1
+            || null !== self::parseHeading($line)
+            || preg_match('/^\s*>\s?(.*)$/', $line) === 1
+            || null !== self::parseListLine($line);
     }
 
     /**
@@ -645,15 +694,16 @@ final class ArticleMarkupRenderer
             '/!\[([^\]]*)\]\((((?i:https?):\/\/|\/uploads\/)[^\s)]+)\)/',
             static function (array $matches): string {
                 $source = htmlspecialchars_decode($matches[2], ENT_QUOTES);
-                if (!self::isAllowedImageSource($source)) {
+                $image = self::renderImage(
+                    htmlspecialchars_decode($matches[1], ENT_QUOTES),
+                    $source,
+                );
+
+                if (null === $image) {
                     return $matches[0];
                 }
 
-                return sprintf(
-                    '<img src="%s" alt="%s" loading="lazy">',
-                    htmlspecialchars($source, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'),
-                    htmlspecialchars(htmlspecialchars_decode($matches[1], ENT_QUOTES), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'),
-                );
+                return $image;
             },
             $escaped,
         ) ?? $escaped;
@@ -679,7 +729,29 @@ final class ArticleMarkupRenderer
             $escaped = preg_replace($pattern, $replacement, $escaped) ?? $escaped;
         }
 
-        return str_replace(self::LINE_BREAK_TOKEN, '<br>', $escaped);
+        return $escaped;
+    }
+
+    private static function renderStandaloneImage(string $content): ?string
+    {
+        if (preg_match('/^!\[([^\]]*)\]\((((?i:https?):\/\/|\/uploads\/)[^\s)]+)\)$/', $content, $matches) !== 1) {
+            return null;
+        }
+
+        return self::renderImage($matches[1], $matches[2]);
+    }
+
+    private static function renderImage(string $alt, string $source): ?string
+    {
+        if (!self::isAllowedImageSource($source)) {
+            return null;
+        }
+
+        return sprintf(
+            '<img src="%s" alt="%s" loading="lazy">',
+            htmlspecialchars($source, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'),
+            htmlspecialchars($alt, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'),
+        );
     }
 
     private static function isAllowedImageSource(string $source): bool

--- a/templates/admin/article/_form.html.twig
+++ b/templates/admin/article/_form.html.twig
@@ -523,7 +523,7 @@
                                     <li><code>&gt; Cytat</code> - cytat blokowy</li>
                                     <li><code>- Element listy</code> - lista punktowana</li>
                                     <li><code>1. Element listy</code> - lista numerowana</li>
-                                    <li><code>Linia 1\</code><br><code>Linia 2</code> - wymuszona nowa linia</li>
+                                    <li><code>Linia 1</code><br><code>Linia 2</code> - nowa linia w akapicie</li>
                                     <li><code>---</code> - separator</li>
                                     <li><code>[tekst](https://...)</code> - link</li>
                                     <li><code>![alt](https://...)</code> - obraz</li>

--- a/tests/Unit/Service/ArticleMarkupRendererTest.php
+++ b/tests/Unit/Service/ArticleMarkupRendererTest.php
@@ -50,6 +50,7 @@ TEXT);
         $this->assertStringContainsString('<blockquote><p>Cytat testowy</p></blockquote>', $html);
         $this->assertStringContainsString('<a href="https://openai.com" target="_blank" rel="noopener noreferrer">OpenAI</a>', $html);
         $this->assertStringContainsString('<img src="https://example.com/test.png" alt="Alt" loading="lazy">', $html);
+        $this->assertStringNotContainsString('<p><img src="https://example.com/test.png" alt="Alt" loading="lazy"></p>', $html);
         $this->assertStringContainsString('<div class="article-code-block">', $html);
         $this->assertStringContainsString('<div class="article-code-scroll">', $html);
         $this->assertStringContainsString('<code class="language-php">', $html);
@@ -79,7 +80,21 @@ TEXT);
 
         $html = $renderer->render('![Obrazek](/uploads/media/2026/04/test-image.webp)');
 
-        $this->assertStringContainsString('<img src="/uploads/media/2026/04/test-image.webp" alt="Obrazek" loading="lazy">', $html);
+        $this->assertSame('<img src="/uploads/media/2026/04/test-image.webp" alt="Obrazek" loading="lazy">', $html);
+    }
+
+    public function testRendersStandaloneImageOutsideParagraphBetweenTextLines(): void
+    {
+        $renderer = new ArticleMarkupRenderer();
+
+        $html = $renderer->render(<<<'TEXT'
+Przed
+![Obrazek](/uploads/media/2026/04/test-image.webp)
+Po
+TEXT);
+
+        $this->assertStringContainsString("<p>Przed</p>\n<img src=\"/uploads/media/2026/04/test-image.webp\" alt=\"Obrazek\" loading=\"lazy\">\n<p>Po</p>", $html);
+        $this->assertStringNotContainsString('<p><img ', $html);
     }
 
     public function testDoesNotRenderImageForSchemeRelativeUrl(): void
@@ -202,9 +217,50 @@ Druga linia
 | `kod` | Wartosc |
 TEXT);
 
-        $this->assertStringContainsString('<p>Pierwsza linia<br>Druga linia</p>', $html);
+        $this->assertStringContainsString("<p>Pierwsza linia</p>\n<p>Druga linia</p>", $html);
         $this->assertStringContainsString('<hr>', $html);
         $this->assertStringContainsString('<div class="article-table-wrap"><table><thead><tr><th>Kolumna A</th><th>Kolumna B</th></tr></thead><tbody><tr><td><code>kod</code></td><td>Wartosc</td></tr></tbody></table></div>', $html);
+    }
+
+    public function testRendersConsecutiveParagraphLinesAsLineBreaksWithoutBackslash(): void
+    {
+        $renderer = new ArticleMarkupRenderer();
+
+        $html = $renderer->render(<<<'TEXT'
+Pierwsza linia
+Druga linia
+Trzecia linia
+TEXT);
+
+        $this->assertStringContainsString("<p>Pierwsza linia</p>\n<p>Druga linia</p>\n<p>Trzecia linia</p>", $html);
+    }
+
+    public function testPreservesBlankParagraphLinesBetweenText(): void
+    {
+        $renderer = new ArticleMarkupRenderer();
+
+        $html = $renderer->render(<<<'TEXT'
+Tresc
+
+
+Tresc
+TEXT);
+
+        $this->assertStringContainsString("<p>Tresc</p>\n<br>\n<br>\n<p>Tresc</p>", $html);
+    }
+
+    public function testPreservesBackslashOnlyLinesBetweenText(): void
+    {
+        $renderer = new ArticleMarkupRenderer();
+
+        $html = $renderer->render(<<<'TEXT'
+Tresc
+\
+\
+Tresc
+TEXT);
+
+        $this->assertStringContainsString("<p>Tresc</p>\n<br>\n<br>\n<p>Tresc</p>", $html);
     }
 
     public function testRendersForcedLineBreakInParagraphImmediatelyAfterTable(): void
@@ -220,7 +276,7 @@ Druga linia
 TEXT);
 
         $this->assertStringContainsString('<div class="article-table-wrap"><table><thead><tr><th>Kolumna A</th><th>Kolumna B</th></tr></thead><tbody><tr><td>Wartosc 1</td><td>Wartosc 2</td></tr></tbody></table></div>', $html);
-        $this->assertStringContainsString('<p>Po tabeli<br>Druga linia</p>', $html);
+        $this->assertStringContainsString("<p>Po tabeli</p>\n<p>Druga linia</p>", $html);
     }
 
     public function testKeepsTableBeforeParagraphWithoutBlankLineAfterTable(): void
@@ -261,7 +317,7 @@ Architektura monolityczna.
 TEXT);
 
         $this->assertStringContainsString('<div class="article-table-wrap"><table><thead><tr><th>Cecha</th><th>Monolit</th><th>Mikroserwisy</th></tr></thead><tbody><tr><td>Deployment</td><td>Jeden</td><td>Wiele</td></tr><tr><td>Skalowanie</td><td>Całość</td><td>Per serwis</td></tr><tr><td>Złożoność</td><td>Niska</td><td>Wysoka</td></tr><tr><td>Wydajność</td><td>Wysoka</td><td>Niższa</td></tr></tbody></table></div>', $html);
-        $this->assertStringContainsString('<p><br><br><br>Architektura monolityczna.</p>', $html);
+        $this->assertStringContainsString("<br>\n<br>\n<br>\n<p>Architektura monolityczna.</p>", $html);
     }
 
     public function testEscapesRawHtml(): void


### PR DESCRIPTION
- Zmieniono renderowanie zwykłej treści artykułu w `ArticleMarkupRenderer`, tak aby każda linia tekstu była osobnym tagiem `<p>`, a puste linie oraz linie z samym `\` były renderowane jako osobne `<br>` bez konieczności łączenia całej treści w jeden paragraf.
- Uspójniono renderowanie bloków nietekstowych w treści artykułu: samodzielne obrazy Markdown są emitowane jako `<img>` poza paragrafem, a tabele pozostają osobnymi blokami HTML bez opakowania w `<p>`.
- Dopasowano style publicznego widoku artykułu do nowej struktury treści, zdejmując dodatkowy odstęp między kolejnymi liniami `<p>` i pustymi liniami `<br>` oraz zmniejszając bazowy `line-height` treści.
- Zaktualizowano podpowiedź formatowania w formularzu artykułu oraz rozszerzono testy jednostkowe renderera o zachowanie pustych linii, linii z `\`, samodzielnych obrazów i tekstowych linii renderowanych jako osobne paragrafy.