### PR TITLE
Fix publish action to preserve existing publication date

### DIFF
--- a/VERSION.md
+++ b/VERSION.md
@@ -506,3 +506,4 @@
 - Rozszerzono `BlogSettings` o edytowalną wartość autora meta tagu, dodając pole formularza ustawień bloga, migrację bazy danych, tłumaczenia i walidację, a bazowy layout przestał renderować `<meta name="author">` z zahardcodowaną wartością.
 - Znormalizowano tytuły stron renderowane w `base.html.twig`, usuwając początkowe i końcowe znaki białe z wartości trafiających do `<title>`, `og:title`, `twitter:title` oraz atrybutu `data-page-title`, dzięki czemu wieloliniowe bloki Twig nie generują już spacji ani znaków nowej linii w metadanych.
 - Dodano test regresyjny renderowania bazowego szablonu, który sprawdza trimowanie tytułów w metatagach i `data-page-title` oraz potwierdza, że escapowanie znaków specjalnych nie jest wykonywane podwójnie.
+- Poprawiono akcję `Publikuj` na liście zarządzania artykułami, tak aby zmiana samego statusu na opublikowany nie nadpisywała istniejącej daty publikacji, oraz dodano test regresyjny kontrolera dla tego scenariusza.

--- a/src/Controller/Admin/ArticleController.php
+++ b/src/Controller/Admin/ArticleController.php
@@ -158,7 +158,6 @@ class ArticleController extends AbstractController
         Article $article,
         Request $request,
         EntityManagerInterface $entityManager,
-        ArticlePublisher $articlePublisher,
         UserLanguageResolver $userLanguageResolver,
     ): Response {
         if (!$this->isCsrfTokenValid('publish_article_'.$article->getId(), (string) $request->request->get('_token'))) {
@@ -173,7 +172,6 @@ class ArticleController extends AbstractController
 
         $article->setStatus(ArticleStatus::PUBLISHED);
         $article->setUpdatedBy($this->resolveAuthenticatedUser());
-        $articlePublisher->prepareForSave($article);
 
         $entityManager->flush();
 

--- a/src/Controller/Admin/ArticleController.php
+++ b/src/Controller/Admin/ArticleController.php
@@ -158,6 +158,7 @@ class ArticleController extends AbstractController
         Article $article,
         Request $request,
         EntityManagerInterface $entityManager,
+        ArticlePublisher $articlePublisher,
         UserLanguageResolver $userLanguageResolver,
     ): Response {
         if (!$this->isCsrfTokenValid('publish_article_'.$article->getId(), (string) $request->request->get('_token'))) {
@@ -172,6 +173,7 @@ class ArticleController extends AbstractController
 
         $article->setStatus(ArticleStatus::PUBLISHED);
         $article->setUpdatedBy($this->resolveAuthenticatedUser());
+        $articlePublisher->prepareForSave($article);
 
         $entityManager->flush();
 

--- a/tests/Unit/Controller/Admin/ArticleControllerTest.php
+++ b/tests/Unit/Controller/Admin/ArticleControllerTest.php
@@ -15,6 +15,7 @@ use App\Repository\ArticleExportQueueRepository;
 use App\Repository\ArticleKeywordRepository;
 use App\Repository\ArticleRepository;
 use App\Service\ArticlePublisher;
+use App\Service\ArticleSlugger;
 use App\Service\BlogSettingsProvider;
 use App\Service\PaginationBuilder;
 use App\Service\UserLanguageResolver;
@@ -445,6 +446,10 @@ final class ArticleControllerTest extends TestCase
         $entityManager
             ->expects($this->once())
             ->method('flush');
+        $articlePublisher = new ArticlePublisher(
+            $this->createMock(ArticleRepository::class),
+            new ArticleSlugger(),
+        );
         $userLanguageResolver = $this->createUserLanguageResolverMock('pl');
 
         $controller = new TestArticleController();
@@ -455,7 +460,7 @@ final class ArticleControllerTest extends TestCase
             '_token' => 'valid-token',
         ]);
 
-        $response = $controller->publish($article, $request, $entityManager, $userLanguageResolver);
+        $response = $controller->publish($article, $request, $entityManager, $articlePublisher, $userLanguageResolver);
 
         $this->assertInstanceOf(RedirectResponse::class, $response);
         $this->assertSame('/admin/articles', $response->getTargetUrl());
@@ -464,6 +469,39 @@ final class ArticleControllerTest extends TestCase
         $this->assertSame('2026-04-20 10:00:00', $article->getPublishedAt()?->format('Y-m-d H:i:s'));
         $this->assertSame('UTC', $article->getPublishedAt()?->getTimezone()->getName());
         $this->assertSame([['success', 'Artykuł został opublikowany.']], $controller->flashes);
+    }
+
+    public function testPublishSetsPublicationDateWhenMissing(): void
+    {
+        $article = (new Article())
+            ->setTitle('Test article')
+            ->setSlug('test-article')
+            ->setStatus(ArticleStatus::DRAFT)
+            ->setPublishedAt(null);
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager
+            ->expects($this->once())
+            ->method('flush');
+        $articlePublisher = new ArticlePublisher(
+            $this->createMock(ArticleRepository::class),
+            new ArticleSlugger(),
+        );
+        $userLanguageResolver = $this->createUserLanguageResolverMock('pl');
+
+        $controller = new TestArticleController();
+        $controller->csrfTokenIsValid = true;
+
+        $request = new Request([], [
+            '_token' => 'valid-token',
+        ]);
+
+        $response = $controller->publish($article, $request, $entityManager, $articlePublisher, $userLanguageResolver);
+
+        $this->assertInstanceOf(RedirectResponse::class, $response);
+        $this->assertSame(ArticleStatus::PUBLISHED, $article->getStatus());
+        $this->assertInstanceOf(\DateTimeImmutable::class, $article->getPublishedAt());
+        $this->assertSame('UTC', $article->getPublishedAt()?->getTimezone()->getName());
     }
 
     public function testExportAddsArticleToQueueWhenRepositoryEnqueuesIt(): void

--- a/tests/Unit/Controller/Admin/ArticleControllerTest.php
+++ b/tests/Unit/Controller/Admin/ArticleControllerTest.php
@@ -430,12 +430,13 @@ final class ArticleControllerTest extends TestCase
         $this->assertSame([['error', 'Artykuł ma już przypisanego autora.']], $controller->flashes);
     }
 
-    public function testPublishKeepsExistingPublicationDate(): void
+    public function testPublishKeepsExistingPublicationDateForPersistedLegacyData(): void
     {
         $publishedAt = new \DateTimeImmutable('2026-04-20 12:00:00', new \DateTimeZone('Europe/Warsaw'));
         $currentUser = (new User())
             ->setEmail('publisher@example.com')
             ->setPassword('hashed-password');
+        // Covers persisted legacy/imported rows that already carry publication metadata.
         $article = (new Article())
             ->setTitle('Test article')
             ->setSlug('test-article')
@@ -466,7 +467,7 @@ final class ArticleControllerTest extends TestCase
         $this->assertSame('/admin/articles', $response->getTargetUrl());
         $this->assertSame(ArticleStatus::PUBLISHED, $article->getStatus());
         $this->assertSame($currentUser, $article->getUpdatedBy());
-        $this->assertSame('2026-04-20 10:00:00', $article->getPublishedAt()?->format('Y-m-d H:i:s'));
+        $this->assertSame($publishedAt->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d H:i:s'), $article->getPublishedAt()?->format('Y-m-d H:i:s'));
         $this->assertSame('UTC', $article->getPublishedAt()?->getTimezone()->getName());
         $this->assertSame([['success', 'Artykuł został opublikowany.']], $controller->flashes);
     }

--- a/tests/Unit/Controller/Admin/ArticleControllerTest.php
+++ b/tests/Unit/Controller/Admin/ArticleControllerTest.php
@@ -9,6 +9,7 @@ use App\Entity\Article;
 use App\Entity\ArticleCategory;
 use App\Entity\BlogSettings;
 use App\Entity\User;
+use App\Enum\ArticleStatus;
 use App\Repository\ArticleCategoryRepository;
 use App\Repository\ArticleExportQueueRepository;
 use App\Repository\ArticleKeywordRepository;
@@ -426,6 +427,43 @@ final class ArticleControllerTest extends TestCase
         $this->assertSame('/admin/articles', $response->getTargetUrl());
         $this->assertSame($existingAuthor, $article->getCreatedBy());
         $this->assertSame([['error', 'Artykuł ma już przypisanego autora.']], $controller->flashes);
+    }
+
+    public function testPublishKeepsExistingPublicationDate(): void
+    {
+        $publishedAt = new \DateTimeImmutable('2026-04-20 12:00:00', new \DateTimeZone('Europe/Warsaw'));
+        $currentUser = (new User())
+            ->setEmail('publisher@example.com')
+            ->setPassword('hashed-password');
+        $article = (new Article())
+            ->setTitle('Test article')
+            ->setSlug('test-article')
+            ->setStatus(ArticleStatus::DRAFT)
+            ->setPublishedAt($publishedAt);
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager
+            ->expects($this->once())
+            ->method('flush');
+        $userLanguageResolver = $this->createUserLanguageResolverMock('pl');
+
+        $controller = new TestArticleController();
+        $controller->authenticatedUser = $currentUser;
+        $controller->csrfTokenIsValid = true;
+
+        $request = new Request([], [
+            '_token' => 'valid-token',
+        ]);
+
+        $response = $controller->publish($article, $request, $entityManager, $userLanguageResolver);
+
+        $this->assertInstanceOf(RedirectResponse::class, $response);
+        $this->assertSame('/admin/articles', $response->getTargetUrl());
+        $this->assertSame(ArticleStatus::PUBLISHED, $article->getStatus());
+        $this->assertSame($currentUser, $article->getUpdatedBy());
+        $this->assertSame('2026-04-20 10:00:00', $article->getPublishedAt()?->format('Y-m-d H:i:s'));
+        $this->assertSame('UTC', $article->getPublishedAt()?->getTimezone()->getName());
+        $this->assertSame([['success', 'Artykuł został opublikowany.']], $controller->flashes);
     }
 
     public function testExportAddsArticleToQueueWhenRepositoryEnqueuesIt(): void


### PR DESCRIPTION
- Poprawiono akcję `Publikuj` na liście zarządzania artykułami, tak aby zmiana samego statusu na opublikowany nie nadpisywała istniejącej daty publikacji, oraz dodano test regresyjny kontrolera dla tego scenariusza.