### PR TITLE
Remove description column from article category index for cleaner layout

### DIFF
--- a/VERSION.md
+++ b/VERSION.md
@@ -523,3 +523,4 @@
 
 - Dodano na `admin_article_index` filtrowanie artykułów po autorze, z zachowaniem wybranego autora podczas paginacji i sortowania oraz obsługą niepoprawnych wartości parametru `author`.
 - Ograniczono dropdown autorów na `admin_article_index` do 10 pozycji opartych o faktycznych autorów artykułów i dodano w nim pole wyszukiwania, które dociąga dopasowanych autorów z backendu.
+- Usunięto kolumnę `Opis` z tabeli na `admin_article_category_index`, zachowując spójny układ pozostałych kolumn i pustego stanu listy.

--- a/templates/admin/article_category/index.html.twig
+++ b/templates/admin/article_category/index.html.twig
@@ -74,10 +74,6 @@
                             <span data-lang="pl" data-i18n="admin_categories_table_title_pl">Tytuł (PL)</span>
                             <span data-lang="en" data-i18n="admin_categories_table_title_en">Title (EN)</span>
                         </th>
-                        <th>
-                            <span data-lang="pl" data-i18n="admin_categories_table_description_pl">Opis (PL)</span>
-                            <span data-lang="en" data-i18n="admin_categories_table_description_en">Description (EN)</span>
-                        </th>
                         <th data-i18n="category_form_icon">Ikona</th>
                         <th data-i18n="admin_table_status">Stan</th>
                         <th data-i18n="admin_table_updated">Aktualizacja</th>
@@ -102,7 +98,6 @@
                                 <strong>{{ category.name }}</strong>
                             </td>
                             <td>{{ category.localizedTitle(user_language) }}</td>
-                            <td>{{ category.localizedDescription(user_language) ?? '—' }}</td>
                             <td><code>{{ category.icon ?? '—' }}</code></td>
                             <td class="article-index-status-cell">
                                 <span data-i18n="{{ category.status.translationKey }}">{{ category.status.label }}</span>
@@ -147,7 +142,7 @@
                         </tr>
                     {% else %}
                         <tr>
-                            <td colspan="8" data-i18n="admin_category_table_empty">Nie znaleziono kategorii.</td>
+                            <td colspan="7" data-i18n="admin_category_table_empty">Nie znaleziono kategorii.</td>
                         </tr>
                     {% endfor %}
                     </tbody>


### PR DESCRIPTION
- Usunięto kolumnę `Opis` z tabeli na `admin_article_category_index`, zachowując spójny układ pozostałych kolumn i pustego stanu listy.